### PR TITLE
Protection against user changing caret position while code movie is running type command

### DIFF
--- a/src/scenario.css
+++ b/src/scenario.css
@@ -1,5 +1,14 @@
 @import url(cm-espresso.css);
 
+.CodeMirror-movie_typing-shield {
+    position: absolute;
+    left:0;
+    top:0;
+    right: 0;
+    bottom:0;
+    z-index: 10;
+}
+
 /* Tooltip */
 .CodeMirror-tooltip {
 	position: absolute;

--- a/src/scenario.js
+++ b/src/scenario.js
@@ -73,12 +73,16 @@ CodeMirror.scenario = (function() {
 			
 			var chars = options.text.split('');
 			
+			var typing_shield = _.dom.toDOM('<div class="CodeMirror-movie_typing-shield"></div>');
+			editor.display.wrapper.appendChild(typing_shield);
+
 			timer(function perform() {
 				var ch = chars.shift();
 				editor.replaceSelection(ch, 'end');
 				if (chars.length) {
 					timer(perform, options.delay);
 				} else {
+					_.dom.remove(typing_shield);
 					next();
 				}
 			}, options.delay);


### PR DESCRIPTION
This change attempts to fight the serious problem created by user accidently changing the caret position while code movie is typing some text.

When typing starts, invisible div is created to cover whole text area and prevent user from changing caret position and messing everything up. Once typing is over, the div is removed.
